### PR TITLE
docs(repo): add contribution guidelines and initialize changelog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,23 @@
 * text=auto
 
+# PHP line endings
+*.php text eol=lf
+
+# Batch files
+*.bat text eol=crlf
+
+# Export-ignore (Exclude from Packagist/Composer archives)
+/.agent                 export-ignore
 /build                  export-ignore
+/docs                   export-ignore
+/examples               export-ignore
 /tests                  export-ignore
 .gitattributes          export-ignore
 .gitignore              export-ignore
+.php-cs-fixer.cache     export-ignore
+.php-cs-fixer.dist.php  export-ignore
+AGENTS.md               export-ignore
+phpcs.xml               export-ignore
+phpstan.neon            export-ignore
 phpunit.xml             export-ignore
 phpcs.xml               export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+### IA ###
+AGENTS.md
+.agent/
+
 ### Composer ###
 
 composer.phar
@@ -25,3 +29,11 @@ composer.phar
 # Ignore all local history of files
 .history
 .ionide
+
+### Analysis & Linting ###
+.php-cs-fixer.cache
+.phpstan.cache.php
+
+### OS Specific ###
+.DS_Store
+Thumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to Mate/simple-logger
+
+Thank you for your interest in contributing to Mate/simple-logger! To maintain a high-quality codebase and a clear history of changes, we follow specific standards.
+
+## Git Conventional Commits
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages. This allows us to automatically generate changelogs and manage versioning effectively.
+
+### Commit Message Format
+
+Each commit message consists of a **header**, a **body**, and a **footer**. The header has a special format that includes a **type**, a **scope**, and a **subject**:
+
+```text
+<type>(<scope>): <subject>
+<blank line>
+<body>
+<blank line>
+<footer>
+```
+
+### Types
+
+The `<type>` must be one of the following:
+
+- **feat**: A new feature for the user, not a new feature for a build script.
+- **fix**: A bug fix for the user, not a fix to a build script.
+- **docs**: Changes to the documentation.
+- **style**: Formatting, missing semi colons, etc; no production code change.
+- **refactor**: Refactoring production code, e.g. renaming a variable.
+- **perf**: Improvements in performance.
+- **test**: Adding missing tests, refactoring tests; no production code change.
+- **build**: Changes that affect the build system or external dependencies (example scopes: composer).
+- **ci**: Changes to our CI configuration files and scripts.
+- **chore**: Other changes that don't modify src or test files.
+- **revert**: Reverts a previous commit.
+
+### Examples
+
+- `feat(core): add asymmetric visibility support`
+- `fix(mapper): resolve issue with null values in strict mode`
+- `docs(readme): add installation instructions for Swoole environments`
+- `perf(collection): optimize array iteration in MapCollection`
+
+### Rules
+
+1. Use the imperative, present tense: "change" not "changed" nor "changes".
+2. Don't capitalize the first letter.
+3. No dot (.) at the end.
+
+## Development Workflow
+
+1. Fork the repository.
+2. Create your feature branch: `git checkout -b feat/my-new-feature`.
+3. Commit your changes following the Conventional Commits standard.
+4. Push to the branch: `git push origin feat/my-new-feature`.
+5. Submit a Pull Request.
+
+## Testing
+
+Ensure all tests pass before submitting a PR:
+
+```bash
+composer test
+```


### PR DESCRIPTION
- Add CONTRIBUTING.md defining Conventional Commits and development workflow.
- Initialize CHANGELOG.md based on Keep a Changelog standard.
- Update .gitignore to exclude AI metadata, analysis caches, and OS files.
- Configure .gitattributes for PHP line endings and archive exclusions.